### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,4 +1,4 @@
-BEGIN { push @*INC, <lib> }
+use lib 'lib';
 use Modular;
 use Test;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
