### PR TITLE
CI pipeline

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,5 +8,5 @@
      },
      "author" : "grondilu",
      "depends" : [ ],
-     "source-url" : "git://github.com/grondilu/finite-field-raku.git"
+     "source-url" : "git@github.com:grondilu/finite-fields-raku.git"
  }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![SparrowCI](https://ci.sparrowhub.io/project/gh-grondilu-finite-fields-raku/badge)](https://ci.sparrowhub.io)
+
 # Finite Fields Aritmetics in raku
 
 ```raku

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -1,0 +1,83 @@
+image:
+  - melezhik/sparrow:debian
+tasks:
+  -
+    name: main
+    default: true
+    language: Raku
+    code: |
+      use Text::Table::Simple;
+      my @columns = ("Rakudo Version", "Status", "Time", "Linux Dist");
+      my @rows;
+      my $fail = False;
+      for config()<tasks><multi-versions><state><list><> -> $i {
+        @rows.push: [ $i<version>, $i<status>,  $i<time>, os() ];
+        $fail = True unless $i<status> eq "OK";
+      }
+      my @table = lol2table(@columns,@rows);
+      .say for @table;
+      die "some tests failed" if $fail == True;
+    depends:
+      -
+        name: multi-versions
+  -
+    name: multi-versions
+    language: Raku
+    config:
+      list:
+        # - 2022.04
+        - 2022.07
+        - 2022.12
+    code: |
+      my @state;
+      for config()<list><> -> $v {
+        my $s = %( version => $v );
+        if "{cache_root_dir()}/{$v}_ok".IO ~~ :e {
+          $s<status> = "OK";
+        } else {
+          $s<status> = "FAIL";
+        }
+        if "{cache_root_dir()}/{$v}_time".IO ~~ :e {
+          $s<time> = "{cache_root_dir()}/{$v}_time".IO.slurp();
+        } else {
+          $s<time> = "NA";
+        }
+        @state.push: $s;
+      }
+      update_state %( list => @state );
+    init: |
+      for config()<list><> -> $v {
+        run_task("test", %( version => $v ));
+      }
+    subtasks:
+      -
+        name: test
+        language: Bash
+        init: |
+          ignore_error
+        code: |
+          set -e
+          echo "Linux version: $os"
+          curl -sL https://rakudo.org/dl/rakudo/rakudo-moar-$version-01-linux-x86_64-gcc.tar.gz \
+          -o rakudo-moar-$version-01-linux-x86_64-gcc.tar.gz
+          tar -xzf rakudo-moar-$version-01-linux-x86_64-gcc.tar.gz          
+          eval "$(rakudo-moar-$version-01-linux-x86_64-gcc/scripts/set-env.sh)"
+          which raku
+          which zef
+          raku --version
+          zef --version
+          
+          cd source/
+          zef install . --deps-only --test-depends --build-depends --/test -to=home         
+          /usr/bin/time -f "%E real,%U user,%S sys | CPU Percentage: %P" -o "${cache_root_dir}/${version}_time" \
+          zef test --debug . && touch "${cache_root_dir}/${version}_ok"
+          
+    depends:
+      -
+        name: install-deps
+  -
+    name: install-deps
+    language: Bash
+    code: |
+      sudo apt-get install -y time 
+      zef install --/test Text::Table::Simple


### PR DESCRIPTION
Hi @grondilu here is CI pipeline for you module. Currently build fails - https://ci.sparrowhub.io/report/2176

```
23:50:47 :: ===> Testing: FiniteFields:ver<0.2.0>
23:50:47 :: [FiniteFields] Testing with plugin: Zef::Service::Shell::prove+{<anon|1>}
23:50:47 :: [FiniteFields] ===SORRY!=== Error while compiling /var/.sparrowdo/env/main/.sparrowdo/source/t/basic.t
23:50:47 :: [FiniteFields] Failed to open file /var/.sparrowdo/env/main/.sparrowdo/source/lib/FiniteField.pm: No such file or directory
23:50:47 :: [FiniteFields] at /var/.sparrowdo/env/main/.sparrowdo/source/t/basic.t:1
23:50:47 :: [FiniteFields] Actually thrown at:
23:50:47 :: [FiniteFields]   in any statement_control at /var/.sparrowdo/env/main/.sparrowdo/rakudo-moar-2022.07-01-linux-x86_64-gcc/bin/../share/perl6/lib/Perl6/Grammar.moarvm line 1
23:50:47 :: [FiniteFields] t/basic.t .. 
23:50:47 :: [FiniteFields] Dubious, test returned 1 (wstat 256, 0x100)
23:50:47 :: [FiniteFields] No subtests run 
23:50:47 :: [FiniteFields] Test Summary Report
23:50:47 :: [FiniteFields] -------------------
23:50:47 :: [FiniteFields] t/basic.t (Wstat: 256 Tests: 0 Failed: 0)
23:50:47 :: [FiniteFields]   Non-zero exit status: 1
23:50:47 :: [FiniteFields]   Parse errors: No plan found in TAP output
23:50:47 :: [FiniteFields] Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.50 cusr  0.06 csys =  0.59 CPU)
23:50:47 :: [FiniteFields] Result: FAIL
```